### PR TITLE
Upgrade Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react": "18.2.45",
         "@types/react-dom": "18.2.18",
         "@vercel/analytics": "^1.1.1",
+        "@vercel/speed-insights": "^1.0.2",
         "autoprefixer": "10.4.16",
         "eslint-config-next": "^14.0.4",
         "next": "^14.0.4",
@@ -2734,6 +2735,12 @@
       "dependencies": {
         "server-only": "^0.0.1"
       }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.2.tgz",
+      "integrity": "sha512-y5HWeB6RmlyVYxJAMrjiDEz8qAIy2cit0fhBq+MD78WaUwQvuBnQlX4+5MuwVTWi46bV3klaRMq83u9zUy1KOg==",
+      "hasInstallScript": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -11704,6 +11711,11 @@
       "requires": {
         "server-only": "^0.0.1"
       }
+    },
+    "@vercel/speed-insights": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.2.tgz",
+      "integrity": "sha512-y5HWeB6RmlyVYxJAMrjiDEz8qAIy2cit0fhBq+MD78WaUwQvuBnQlX4+5MuwVTWi46bV3klaRMq83u9zUy1KOg=="
     },
     "abab": {
       "version": "2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/node": "20.10.5",
         "@types/react": "18.2.45",
         "@types/react-dom": "18.2.18",
-        "@vercel/analytics": "^1.1.1",
         "@vercel/speed-insights": "^1.0.2",
         "autoprefixer": "10.4.16",
         "eslint-config-next": "^14.0.4",
@@ -2726,14 +2725,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.1.1.tgz",
-      "integrity": "sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==",
-      "dependencies": {
-        "server-only": "^0.0.1"
       }
     },
     "node_modules/@vercel/speed-insights": {
@@ -8691,11 +8682,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
-    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -11702,14 +11688,6 @@
       "requires": {
         "@typescript-eslint/types": "6.15.0",
         "eslint-visitor-keys": "^3.4.1"
-      }
-    },
-    "@vercel/analytics": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.1.1.tgz",
-      "integrity": "sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==",
-      "requires": {
-        "server-only": "^0.0.1"
       }
     },
     "@vercel/speed-insights": {
@@ -15864,11 +15842,6 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "set-function-name": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.18",
     "@vercel/analytics": "^1.1.1",
+    "@vercel/speed-insights": "^1.0.2",
     "autoprefixer": "10.4.16",
     "eslint-config-next": "^14.0.4",
     "next": "^14.0.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@types/node": "20.10.5",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.18",
-    "@vercel/analytics": "^1.1.1",
     "@vercel/speed-insights": "^1.0.2",
     "autoprefixer": "10.4.16",
     "eslint-config-next": "^14.0.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
-import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Inter } from 'next/font/google';
 import Footer from './Footer';
 import Header from './Header';
@@ -32,7 +32,7 @@ export default function RootLayout({
 
           <Footer />
 
-          <Analytics />
+          <SpeedInsights />
         </body>
       </html>
     </Providers>


### PR DESCRIPTION
Vercel recently changed their approach to how they collect analytics data. To participate in the changes, we need to upgrade to using a different package: [@vercel/speed-insights](https://vercel.com/docs/speed-insights/package)

Resolves #46 